### PR TITLE
Made reference filter bar sticky and added some styles

### DIFF
--- a/docs/src/components/Reference/index.module.css
+++ b/docs/src/components/Reference/index.module.css
@@ -8,19 +8,25 @@
 .input {
   width: 100%;
   position: sticky;
-  top: 0;
+  top: 60px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-grow: 1;
   gap: 10px;
   padding: 5px 5px;
+  height: 80px;
+  background-color: #FFFFFF;
 }
 
 .search input {
   flex-grow: 1;
   font-size: 1.2em;
   padding: 0.2em 0.4em;
+  height: 40px;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  width: 50px;
 }
 .search h2, .search input {
   font-family: monospace;


### PR DESCRIPTION
The reference filter bar is sticky and I added some styles to it as well.
<img width="1440" alt="Screenshot 2024-05-23 at 1 22 36 AM" src="https://github.com/LIPS-scheme/lips/assets/84982665/270da276-a9db-4097-b747-684ef30ce465">
This is how it looks like.